### PR TITLE
Adds SMACKcraft Querying Command

### DIFF
--- a/cogs/orb_commands.py
+++ b/cogs/orb_commands.py
@@ -14,12 +14,15 @@ import requests
 from datetime import date, datetime
 from google.cloud import firestore
 from bs4 import BeautifulSoup
+from mcstatus import JavaServer
+import math
 
 from cogs.orb_control import allowed_channel, db
+from utils.repo import SMACKCRAFT
 
 COMMANDS_VERSION = {
-    "Version": "9",
-    "Count": "27"
+    "Version": "10",
+    "Count": "28"
 }
 
 # PUBLIC list of commands, not all of them
@@ -324,6 +327,23 @@ class CommandsCog(bot_commands.Cog):
         if allowed_channel(ctx):
             await ctx.trigger_typing()
             await ctx.send(file=discord.File(fp="images/salty.jpeg"))
+
+    @bot_commands.command(aliases=["mc"])
+    async def smackcraft(self, ctx):
+        if allowed_channel(ctx):
+            smckcrft = JavaServer.lookup(SMACKCRAFT) # move this to config later
+
+            try:
+                status = smckcrft.status()
+                embed = discord.Embed(title="SMACKcraft", description=status.description, color=0x287233)
+                embed.add_field(name="Active Players:", value=str(status.players.online))
+                embed.add_field(name="Version:", value=str(status.version.name))
+                embed.add_field(name="Latency:", value=round(status.latency, 2))
+
+                await ctx.send(embed=embed)
+
+            except Exception as e:
+                await ctx.send("An error was encountered when trying to query the server. Is it offline?")
 
     # Dev
     @bot_commands.command()

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ psutil>=5.6.7
 saucenao-api==2.3.0
 beautifulsoup4==4.9.3
 requests>=2.23.0
+mcstatus==9.0.4

--- a/utils/repo.py
+++ b/utils/repo.py
@@ -27,7 +27,9 @@ BANNED_CHANNELS = "x"
 PIN_DATA = config['optional_cogs']['pin_settings']
 LOAD_BALANCER = config['optional_cogs']['load_balancer_settings']
 REACTIONS = config['reaction_data']
-SMACKCRAFT = config['smackcraft']
+
+# Consts
+SMACKCRAFT = "103.62.50.44:25565" # As of (06/04/2022)
 
 # Get prefixes
 def get_prefix(bot, message):

--- a/utils/repo.py
+++ b/utils/repo.py
@@ -27,6 +27,7 @@ BANNED_CHANNELS = "x"
 PIN_DATA = config['optional_cogs']['pin_settings']
 LOAD_BALANCER = config['optional_cogs']['load_balancer_settings']
 REACTIONS = config['reaction_data']
+SMACKCRAFT = config['smackcraft']
 
 # Get prefixes
 def get_prefix(bot, message):


### PR DESCRIPTION
A very simple little command. Just querys the SMACKcraft server so we can see the status. Returns description, active players, version, and latency. See screenshot for details.

<img width="607" alt="Screen Shot 2022-04-05 at 10 50 16 pm" src="https://user-images.githubusercontent.com/30831649/161757889-d99a9e57-9142-4422-a32f-6979551ad110.png">

*The SMACKcraft IP is read from the config file.